### PR TITLE
Corrected 'Country name' hint on profileEntryFragment back

### DIFF
--- a/Projects/Project1/app/src/main/java/com/example/mcresswell/project01/fragments/ProfileEntryFragment.java
+++ b/Projects/Project1/app/src/main/java/com/example/mcresswell/project01/fragments/ProfileEntryFragment.java
@@ -301,6 +301,7 @@ public class ProfileEntryFragment extends Fragment implements View.OnClickListen
         //TODO: Uncomment the code below once the fitness profile view model is working
 //        userViewModel.getUser().observe(this, user -> {
 //            if (user != null) {
+//        Log.d(LOG_TAG, String.format("Inserting new fitness profile with userId value of %d", user.getId()));
 //                //Retrieve the userID from UserViewModel for entering in profile_id field of new fitness profile record
 //                tmp_fitnessProfile.setM_userID(user.getId());
 //                m_fitnessProfileViewModel.insertNewFitnessProfile(tmp_fitnessProfile);

--- a/Projects/Project1/app/src/main/res/layout/fragment_profile_entry.xml
+++ b/Projects/Project1/app/src/main/res/layout/fragment_profile_entry.xml
@@ -241,7 +241,7 @@
                 android:ems="10"
                 android:hint="@string/hint_country"
                 android:inputType="textPersonName"
-                android:maxLength="2"
+                android:maxLength="35"
                 android:textSize="18sp"
                 app:layout_constraintEnd_toEndOf="@+id/txtv_city"
                 app:layout_constraintHorizontal_bias="0.0"

--- a/Projects/Project1/app/src/main/res/values/strings.xml
+++ b/Projects/Project1/app/src/main/res/values/strings.xml
@@ -23,7 +23,7 @@
     <string name="hint_inches">Inches</string>
     <string name="hint_weight">Weight</string>
     <string name="hint_city">City</string>
-    <string name="hint_country">US</string>
+    <string name="hint_country">Country Name</string>
     <string name="btn_done">Done</string>
     <string name="btn_img_description_profile_image">Take a profile picture</string>
     <string name="hint_dob">DOB</string>


### PR DESCRIPTION
"Country name" hint on profileEntryFragment keeps getting changed to "US". Implemented a country code mapper a couple of days ago that maps the user's actual country name to 2 letter country code, so this change needs to stay. modified max country name length to 35 characters